### PR TITLE
slim down image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update && \
 
 RUN wget https://ghidra-sre.org/${GHIDRA_VERSION}.zip && \
     unzip -d ghidra ${GHIDRA_VERSION}.zip && \
-    rm ${GHIDRA_VERSION}.zip
-
-RUN mv ghidra/ghidra_* /opt/ghidra
+    rm ${GHIDRA_VERSION}.zip && \
+    mv ghidra/ghidra_* /opt/ghidra
 
 ENV PATH="/opt/ghidra:/opt/ghidra/support:${PATH}"


### PR DESCRIPTION
The image contained 2 copies of Ghidra, one of which only existed in the image history. This change prevents that and thus should slim down the image size by about 900MB.