### PR TITLE
switched to Ghidra 10.0.4 and added fontconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM openjdk:jdk-slim
 
-ENV GHIDRA_RELEASE_TAG Ghidra_10.0.1_build
-ENV GHIDRA_VERSION ghidra_10.0.1_PUBLIC_20210708
+ENV GHIDRA_RELEASE_TAG Ghidra_10.0.4_build
+ENV GHIDRA_VERSION ghidra_10.0.4_PUBLIC_20210928
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget unzip && \
+    apt-get install -y --no-install-recommends wget unzip fontconfig && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Updates to Ghidra 10.0.4 and also adds the fontconfig package. In my tests Ghidra was throwing an error on startup when fontconfig was not installed. This problem also exists with the previous Dockerhub image based on Ghidra 10.0.1, which I could not use because of this.