### PR TITLE
update to Ghidra 10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jdk-slim
 
-ENV GHIDRA_RELEASE_TAG Ghidra_10.0.4_build
-ENV GHIDRA_VERSION ghidra_10.0.4_PUBLIC_20210928
+ENV GHIDRA_RELEASE_TAG Ghidra_10.1_build
+ENV GHIDRA_VERSION ghidra_10.1_PUBLIC_20211210
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget unzip fontconfig && \


### PR DESCRIPTION
Updates the contained Ghidra version to 10.1.

I checked with the cwe_checker that the resulting Docker image works as intended.