### PR TITLE
update Ghidra to 10.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jdk-slim
 
-ENV GHIDRA_RELEASE_TAG Ghidra_10.1.1_build
-ENV GHIDRA_VERSION ghidra_10.1.1_PUBLIC_20211221
+ENV GHIDRA_RELEASE_TAG Ghidra_10.1.2_build
+ENV GHIDRA_VERSION ghidra_10.1.2_PUBLIC_20220125
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget unzip fontconfig && \


### PR DESCRIPTION
Update the contained Ghidra version to 10.1.2, which contains another security update for log4j.