### PR TITLE
Add support to AArch64 machine

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,16 @@
+FROM --platform=linux/arm64/v8 openjdk:jdk-slim
+
+ENV GHIDRA_RELEASE_TAG Ghidra_10.1.2_build
+ENV GHIDRA_VERSION ghidra_10.1.2_PUBLIC_20220125
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget unzip fontconfig && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/NationalSecurityAgency/ghidra/releases/download/${GHIDRA_RELEASE_TAG}/${GHIDRA_VERSION}.zip && \
+    unzip -d ghidra ${GHIDRA_VERSION}.zip && \
+    rm ${GHIDRA_VERSION}.zip && \
+    mv ghidra/ghidra_* /opt/ghidra
+
+ENV PATH="/opt/ghidra:/opt/ghidra/support:${PATH}"


### PR DESCRIPTION
As mentioned in cwe_checker PR: [Add support to AArch64 machine #321](https://github.com/fkie-cad/cwe_checker/pull/321#issuecomment-1114514993)