### PR TITLE
Update to Ghidra 10.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jdk-slim
 
-ENV GHIDRA_RELEASE_TAG Ghidra_10.1.2_build
-ENV GHIDRA_VERSION ghidra_10.1.2_PUBLIC_20220125
+ENV GHIDRA_RELEASE_TAG Ghidra_10.2.2_build
+ENV GHIDRA_VERSION ghidra_10.2.2_PUBLIC_20221115
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget unzip fontconfig && \


### PR DESCRIPTION
Note that Ghidra 10.2 contains a [breaking change in the API](https://github.com/NationalSecurityAgency/ghidra/issues/4255), so scripts based on this Docker image may need to be updated.