### PR TITLE
Build and push the Docker image for releases

### DIFF
--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -1,0 +1,39 @@
+name: Publish Docker images for release versions
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get tag name
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: |
+            linux/amd64
+          push: true
+          tags: |
+            fkiecad/ghidra_headless_base:${{ steps.tagName.outputs.tag }}


### PR DESCRIPTION
Adds a Github action for building and pushing the Docker image to Dockerhub on releases.

Currently the action uses the full tag as image version tag. This would result in a different naming scheme than currently, e.g. the current release would get a `fkiecad/ghidra_headless_base:v10.2.2` tag with this action. We could either add a Regex to the get-tag action or change our tag naming scheme to preserve the Docker image naming scheme. What would you prefer?

Oh, and we need to add a Dockerhub token to the repository.