### PR TITLE
Update to Ghidra 10.2.3

### DIFF
--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -28,6 +28,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to ghcr.io Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
@@ -36,4 +43,5 @@ jobs:
             linux/amd64
           push: true
           tags: |
+            ghcr.io/fkie-cad/ghidra_headless_base:${{ steps.tagName.outputs.tag }}
             fkiecad/ghidra_headless_base:${{ steps.tagName.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:jdk-slim
 
-ENV GHIDRA_RELEASE_TAG Ghidra_10.2.2_build
-ENV GHIDRA_VERSION ghidra_10.2.2_PUBLIC_20221115
+ENV GHIDRA_RELEASE_TAG Ghidra_10.2.3_build
+ENV GHIDRA_VERSION ghidra_10.2.3_PUBLIC_20230208
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget unzip fontconfig && \


### PR DESCRIPTION
also add the Github container registry as a target for automated builds.