### PR TITLE
docker: allow installing Ghidra natives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM openjdk:jdk-slim
 
 ENV GHIDRA_RELEASE_TAG Ghidra_11.0.3_build
 ENV GHIDRA_VERSION ghidra_11.0.3_PUBLIC_20240410
+ENV GRADLE_VERSION gradle-8.10.1
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget unzip fontconfig && \
+    apt-get install -y --no-install-recommends wget unzip fontconfig make gcc g++ && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -12,5 +13,14 @@ RUN wget https://github.com/NationalSecurityAgency/ghidra/releases/download/${GH
     unzip -d ghidra ${GHIDRA_VERSION}.zip && \
     rm ${GHIDRA_VERSION}.zip && \
     mv ghidra/ghidra_* /opt/ghidra
+
+RUN wget https://services.gradle.org/distributions/${GRADLE_VERSION}-bin.zip && \
+    unzip -d gradle ${GRADLE_VERSION}-bin.zip && \
+    rm ${GRADLE_VERSION}-bin.zip && \
+    mv gradle /opt && \
+    PATH=$PATH:/opt/gradle/${GRADLE_VERSION}/bin /opt/ghidra/support/buildNatives && \
+    rm -rf /opt/gradle && \
+    apt-get remove -y make gcc g++ && \
+    apt-get autoremove -y
 
 ENV PATH="/opt/ghidra:/opt/ghidra/support:${PATH}"


### PR DESCRIPTION
This commit adds support for building Ghidra natives.

In turn, this allows for aarch64 linux support, since Ghidra by default does not provide aarch64 prebuilds. I do not have an x86 machine to test on, but this does work well on aarch64.

Resolves: https://github.com/fkie-cad/docker_ghidra_headless_base/issues/13
